### PR TITLE
Added a check using os.makedirs() to create the 'synnax-submissions' …

### DIFF
--- a/tutorials/onboarding_manual.ipynb
+++ b/tutorials/onboarding_manual.ipynb
@@ -1377,16 +1377,17 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 169,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Save the updated submission file\n",
+  "cell_type": "code",
+  "execution_count": null,
+  "metadata": {},
+  "outputs": [],
+  "source": [
+    "import os\n",
+    "os.makedirs('synnax-submissions', exist_ok=True)\n",
     "submission_path = 'synnax-submissions/submission.csv'\n",
     "sample_submission.to_csv(submission_path, index=False)"
-   ]
-  },
+  ]
+}
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/tutorials/onboarding_manual.ipynb
+++ b/tutorials/onboarding_manual.ipynb
@@ -1378,7 +1378,7 @@
   },
   {
   "cell_type": "code",
-  "execution_count": null,
+  "execution_count": 169,
   "metadata": {},
   "outputs": [],
   "source": [


### PR DESCRIPTION
…directory

This PR adds a check to ensure that the target directory exists before saving the submission file. If the directory does not exist, it will be created automatically to prevent an OSError.